### PR TITLE
Show additional urls for build files in stdout

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -62,7 +62,7 @@ presets:
 
 ## Step 3 - create the `bundle-config.yml` or `json` file as noted above.
 
-This is what determines the parent-child relationship. This file is 
+This is what determines the parent-child relationship. This file is
 read from disk every time the `/build.json` or `/loaders.js` endpoint is
 requested - which means you can navigate around the site and continue
 to tweak these relationships to get the optimal result.
@@ -126,7 +126,7 @@ At any point, you can access the following endpoints to retrieve the generated j
 
 |Path|Purpose|
 |---|---|
-|`/__bs/build.json`|Generates the configuration needed for the Optimzer|
+|`/__bs/build.json`|Generates the configuration needed for the Optimizer|
 |`/__bs/loaders.js`|Generates the JavaScript needed to load additional bundles|
 |`/__bs/seed.json`|Generates a dump of the current state so that you can pick up where you left off|
 
@@ -134,8 +134,8 @@ At any point, you can access the following endpoints to retrieve the generated j
 
 ## Using `build.json`
 
-You'll first need to run `static-content:deploy` to ensure all assets are accessible to the optimizer - 
-once you've done that, you'll need to `mv` the entire locale folder and then run the r_js tool using the 
+You'll first need to run `static-content:deploy` to ensure all assets are accessible to the optimizer -
+once you've done that, you'll need to `mv` the entire locale folder and then run the r_js tool using the
 build.json
 
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,9 @@ fn main() {
     match ProgramOptions::from_args(&mut std::env::args_os()).and_then(system::create) {
         Ok((sys, url)) => {
             println!("{}", url);
+            println!("{}/__bs/build.json\t(Generates the configuration needed for the Optimizer)", url);
+            println!("{}/__bs/loaders.js\t(Generates the JavaScript needed to load additional bundles)", url);
+            println!("{}/__bs/seed.json\t(Generates a dump of the current state so that you can pick up where you left off)", url);
             let _ = sys.run();
         }
         Err(e) => {


### PR DESCRIPTION
I thought this would be a nice addition!

When starting the program, output would look like the following:
```
https://127.0.0.1:40513
https://127.0.0.1:40513/__bs/build.json	(Generates the configuration needed for the Optimizer)
https://127.0.0.1:40513/__bs/loaders.js	(Generates the JavaScript needed to load additional bundles)
https://127.0.0.1:40513/__bs/seed.json	(Generates a dump of the current state so that you can pick up where you left off)
```

This way you could open the build urls directly in the browser, instead of fiddling with the given url to open it. 

*Edit: changed the output sample.*