### PR TITLE
Fix for timeout errors 

### DIFF
--- a/src/lib/without_body.rs
+++ b/src/lib/without_body.rs
@@ -6,6 +6,7 @@ use actix_web::{AsyncResponder, Body, Error, HttpMessage, HttpRequest, HttpRespo
 use futures::future::{ok, Either};
 use futures::{Future, Stream};
 
+use std::time::Duration;
 use app_state::AppState;
 use preset::RewriteFns;
 use proxy_transform::create_outgoing;
@@ -33,6 +34,7 @@ pub fn forward_request_without_body(
         .finish()
         .unwrap()
         .send()
+        .timeout(Duration::from_secs(5))
         .map_err(Error::from)
         .and_then(move |proxy_response: ClientResponse| {
             debug!("Got proxy response, status={}", proxy_response.status());


### PR DESCRIPTION
Fix issue with "actix_web::pipeline: Error occured during request handling, status: 504 Gateway Timeout Timeout while waiting for response" that happens in some projects.

On clean magento 2 installation I didn't notice this error.

Later we should add --timeout=XXX argument to CLI as it can be to high/low value for some cases.